### PR TITLE
fix regenerate add user prompt template to content

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -273,7 +273,8 @@
 				childrenIds: [],
 				role: 'user',
 				user: _user ?? undefined,
-				content: getUserPrompt($chatType, userPrompt, $promptOptions),
+				// content: getUserPrompt($chatType, userPrompt, $promptOptions),
+				content: userPrompt,
 				files: files.length > 0 ? files : undefined,
 				models: selectedModels.filter((m, mIdx) => selectedModels.indexOf(m) === mIdx),
 				timestamp: Math.floor(Date.now() / 1000) // Unix epoch

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -271,7 +271,8 @@
 				childrenIds: [],
 				role: 'user',
 				user: _user ?? undefined,
-				content: getUserPrompt($chatType, userPrompt, $promptOptions),
+				// content: getUserPrompt($chatType, userPrompt, $promptOptions),
+				content: userPrompt,
 				files: files.length > 0 ? files : undefined,
 				timestamp: Math.floor(Date.now() / 1000), // Unix epoch
 				models: selectedModels


### PR DESCRIPTION
- When submitPrompt is executed, sendPrompt used original userPrompt.
- When regenerateResponse is executed, sendPrompt used text generated from getUserPrompt.

Temporary fix: Don't save text generated from getUserPrompt to history, save original userPrompt to history.